### PR TITLE
Add user creation sheet

### DIFF
--- a/src/app/admin/users/all/components/add-user-sheet.tsx
+++ b/src/app/admin/users/all/components/add-user-sheet.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import React, { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+    Sheet,
+    SheetContent,
+    SheetHeader,
+    SheetTitle,
+    SheetDescription,
+    SheetFooter,
+    SheetClose
+} from "@/components/ui/sheet";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { useForm, Controller } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import useUsersManagement from "../hooks/useUsersManagement";
+import { useTranslations } from "next-intl";
+import { UserCreateDto } from "@/api/client/types.gen";
+import { zUserCreateDto } from "@/api/client/zod.gen";
+
+interface AddUserSheetProps {
+    children: React.ReactNode;
+}
+
+export const AddUserSheet: React.FC<AddUserSheetProps> = ({ children }) => {
+    const t = useTranslations("Admin.users.all.addUserSheet");
+    const [isOpen, setIsOpen] = useState(false);
+    const { createUser, isCreatingUser } = useUsersManagement();
+
+    const { control, handleSubmit, reset, formState: { errors, isSubmitting } } = useForm<UserCreateDto>({
+        resolver: zodResolver(zUserCreateDto),
+        defaultValues: {
+            auth0Id: "",
+            username: "",
+            email: "",
+            status: "ACTIVE"
+        }
+    });
+
+    const onSubmit = (data: UserCreateDto) => {
+        createUser(data);
+        reset();
+        setIsOpen(false);
+    };
+
+    return (
+        <Sheet open={isOpen} onOpenChange={setIsOpen}>
+            <div onClick={() => setIsOpen(true)} style={{ display: 'inline-block' }}>
+                {children}
+            </div>
+            <SheetContent className="sm:max-w-lg">
+                <SheetHeader>
+                    <SheetTitle>{t("title")}</SheetTitle>
+                    <SheetDescription>
+                        {t("description")}
+                    </SheetDescription>
+                </SheetHeader>
+                <form onSubmit={handleSubmit(onSubmit)} className="space-y-6 py-6">
+                    <div className="space-y-2">
+                        <Label htmlFor="auth0Id">{t("formLabels.auth0Id")}</Label>
+                        <Controller
+                            name="auth0Id"
+                            control={control}
+                            render={({ field }) => (
+                                <Input id="auth0Id" {...field} placeholder={t("placeholders.auth0Id")} />
+                            )}
+                        />
+                        {errors.auth0Id && <p className="text-sm text-red-500">{errors.auth0Id.message}</p>}
+                    </div>
+                    <div className="space-y-2">
+                        <Label htmlFor="username">{t("formLabels.username")}</Label>
+                        <Controller
+                            name="username"
+                            control={control}
+                            render={({ field }) => (
+                                <Input id="username" {...field} placeholder={t("placeholders.username")} />
+                            )}
+                        />
+                        {errors.username && <p className="text-sm text-red-500">{errors.username.message}</p>}
+                    </div>
+                    <div className="space-y-2">
+                        <Label htmlFor="email">{t("formLabels.email")}</Label>
+                        <Controller
+                            name="email"
+                            control={control}
+                            render={({ field }) => (
+                                <Input id="email" type="email" {...field} placeholder={t("placeholders.email")} />
+                            )}
+                        />
+                        {errors.email && <p className="text-sm text-red-500">{errors.email.message}</p>}
+                    </div>
+                    <div className="space-y-2">
+                        <Label htmlFor="status">{t("formLabels.status")}</Label>
+                        <Controller
+                            name="status"
+                            control={control}
+                            render={({ field }) => (
+                                <Select onValueChange={field.onChange} defaultValue={field.value} value={field.value}>
+                                    <SelectTrigger id="status">
+                                        <SelectValue placeholder={t("formLabels.status")} />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        <SelectItem value="ACTIVE">ACTIVE</SelectItem>
+                                        <SelectItem value="PENDING">PENDING</SelectItem>
+                                        <SelectItem value="SUSPENDED">SUSPENDED</SelectItem>
+                                        <SelectItem value="DEACTIVATED">DEACTIVATED</SelectItem>
+                                    </SelectContent>
+                                </Select>
+                            )}
+                        />
+                        {errors.status && <p className="text-sm text-red-500">{errors.status.message}</p>}
+                    </div>
+
+                    <SheetFooter className="mt-8">
+                        <SheetClose asChild>
+                            <Button type="button" variant="outline" onClick={() => reset()}>
+                                {t("buttons.cancel")}
+                            </Button>
+                        </SheetClose>
+                        <Button type="submit" disabled={isSubmitting || isCreatingUser}>
+                            {isSubmitting || isCreatingUser ? "..." : t("buttons.create")}
+                        </Button>
+                    </SheetFooter>
+                </form>
+            </SheetContent>
+        </Sheet>
+    );
+};
+
+export default AddUserSheet;

--- a/src/app/admin/users/all/components/user-admin-table.tsx
+++ b/src/app/admin/users/all/components/user-admin-table.tsx
@@ -3,7 +3,6 @@
 import React, {useEffect} from "react";
 import {ColumnDef, RowSelectionState} from "@tanstack/react-table";
 import {CheckCircle2Icon, LoaderIcon, MailIcon, MoreVerticalIcon, PlusIcon,} from "lucide-react";
-import {toast} from "sonner";
 import {useTranslations} from "next-intl";
 
 import {Badge} from "@/components/ui/badge";
@@ -26,6 +25,7 @@ import {UserIntroduction} from "@/api/client";
 import useUsersStore from "@/app/admin/users/all/store/useUsersStore";
 import useUsersManagement from "../hooks/useUsersManagement";
 import {useUserTableActions} from "@/app/admin/users/all/components/use-user-table-actions";
+import AddUserSheet from "./add-user-sheet";
 
 export type UserAdminData = UserIntroduction & DraggableItem;
 
@@ -194,12 +194,13 @@ export function UserAdminTable() {
                     </TabsTrigger>
                 </TabsList>
                 <div className="flex items-center gap-2">
-                    <Button variant="default" size="sm" className="gap-1.5"
-                            onClick={() => toast.success("Add User Clicked!")}>
-                        <PlusIcon className="size-4"/>
-                        <span className="hidden lg:inline">{t('table.addUser')}</span>
-                        <span className="lg:hidden">{t('table.add')}</span>
-                    </Button>
+                    <AddUserSheet>
+                        <Button variant="default" size="sm" className="gap-1.5">
+                            <PlusIcon className="size-4"/>
+                            <span className="hidden lg:inline">{t('table.addUser')}</span>
+                            <span className="lg:hidden">{t('table.add')}</span>
+                        </Button>
+                    </AddUserSheet>
                 </div>
             </div>
 

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -830,6 +830,25 @@
           "userAttendance": "User Attendance",
           "userAttendanceDescription": "Showing new users per day for the last {days} days",
           "newUsers": "New Users"
+        },
+        "addUserSheet": {
+          "title": "Add New User",
+          "description": "Provide details below to create a new user.",
+          "formLabels": {
+            "auth0Id": "Auth0 ID",
+            "username": "Username",
+            "email": "Email",
+            "status": "Status"
+          },
+          "placeholders": {
+            "auth0Id": "auth0|123",
+            "username": "johndoe",
+            "email": "johndoe@example.com"
+          },
+          "buttons": {
+            "cancel": "Cancel",
+            "create": "Create User"
+          }
         }
       },
       "roles": {

--- a/src/messages/vn.json
+++ b/src/messages/vn.json
@@ -822,6 +822,25 @@
           "userAttendance": "Người dùng tham gia",
           "userAttendanceDescription": "Hiển thị số người dùng mới mỗi ngày trong {days} ngày qua",
           "newUsers": "Người dùng mới"
+        },
+        "addUserSheet": {
+          "title": "Thêm Người Dùng Mới",
+          "description": "Nhập thông tin để tạo người dùng mới.",
+          "formLabels": {
+            "auth0Id": "Auth0 ID",
+            "username": "Tên người dùng",
+            "email": "Email",
+            "status": "Trạng thái"
+          },
+          "placeholders": {
+            "auth0Id": "auth0|123",
+            "username": "tendangnhap",
+            "email": "vidu@example.com"
+          },
+          "buttons": {
+            "cancel": "Hủy",
+            "create": "Tạo Người Dùng"
+          }
         }
       },
       "roles": {


### PR DESCRIPTION
## Summary
- enable creating users in admin section
- add translations for Add User form

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_b_684d41373370832690bfab8218f896b4