### PR TITLE
Refactor admin posts hooks

### DIFF
--- a/src/app/(home)/discover/components/DiscorverMoreAction.tsx
+++ b/src/app/(home)/discover/components/DiscorverMoreAction.tsx
@@ -6,7 +6,7 @@ import {
     DropdownMenuTrigger
 } from "@/components/ui/dropdown-menu";
 import {MoreVertical} from "lucide-react";
-import {useFeedActions} from "@/app/(home)/foryou/hooks/useFeedAction";
+import {useFeed} from "@/app/(home)/foryou/hooks/useFeed";
 import React from "react";
 import {toast} from "sonner";
 import Link from "next/link";
@@ -15,7 +15,7 @@ import {useTranslations} from "next-intl";
 export const DiscoverMoreAction = ({postId} : {postId: string}) => {
     const actionsT = useTranslations("Home.posts.actions");
     const reportT = useTranslations("Home.posts.report");
-    const {handleBookmark, handleReportPost} = useFeedActions();
+    const {handleBookmark, handleReportPost} = useFeed();
 
     // Get report reasons from translations
     const reportReasons = [

--- a/src/app/(home)/foryou/ForyouContainer.tsx
+++ b/src/app/(home)/foryou/ForyouContainer.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, {useRef} from "react";
-import {useFeedActions} from "@/app/(home)/foryou/hooks/useFeedAction";
+import {useFeedSync} from "@/app/(home)/foryou/hooks/useFeedSync";
 import {FeedListUI} from "@/app/components/post-presentation/FeedListUI";
 
 export const ForyouContainer = ({ postId }: { postId?: string }) => {
@@ -12,7 +12,7 @@ export const ForyouContainer = ({ postId }: { postId?: string }) => {
         isFetchingNextPage,
         fetchNextPage,
         hasNextPage,
-    } = useFeedActions(postId);
+    } = useFeedSync(postId);
 
     return (
         <FeedListUI

--- a/src/app/(home)/foryou/hooks/useFeedRealtime.ts
+++ b/src/app/(home)/foryou/hooks/useFeedRealtime.ts
@@ -1,0 +1,34 @@
+import {useChannel} from "ably/react";
+import {useFeedStore} from "../store/useFeedStore";
+import {useCurrentUser} from "@/stores/useCurrentUser";
+import {Feed} from "@/types/Feed";
+
+export const useFeedRealtime = () => {
+    const {user} = useCurrentUser();
+    const {addFeed, addFeeds, updateFeed, removeFeed, removeFeeds} = useFeedStore();
+
+    useChannel("posts", (message) => {
+        const {name, data, clientId} = message;
+        if (clientId === user?.id) return;
+
+        switch (name) {
+            case "post.created":
+                addFeed(data as Feed);
+                break;
+            case "post.updated":
+                updateFeed((data as Feed).post.id, () => data as Feed);
+                break;
+            case "post.deleted":
+                removeFeed(data.postId as string);
+                break;
+            case "posts.bulk-created":
+                addFeeds(data.posts as Feed[]);
+                break;
+            case "posts.bulk-deleted":
+                removeFeeds(data.postIds as string[]);
+                break;
+            default:
+                console.warn(`[Ably] Unknown event "${name}" on posts channel`);
+        }
+    });
+};

--- a/src/app/(home)/foryou/hooks/useFeedSync.ts
+++ b/src/app/(home)/foryou/hooks/useFeedSync.ts
@@ -1,0 +1,21 @@
+import {useEffect} from "react";
+import {useFeed} from "./useFeed";
+import {useFeedStore} from "../store/useFeedStore";
+
+export const useFeedSync = (excludePostId?: string) => {
+    const feed = useFeed(excludePostId);
+    const {setFeeds, feeds: storeFeeds, addFeed, removeFeed, clearFeeds, updateFeed} = useFeedStore();
+
+    useEffect(() => {
+        setFeeds(feed.fetchedFeeds);
+    }, [feed.fetchedFeeds, setFeeds]);
+
+    return {
+        ...feed,
+        feeds: storeFeeds,
+        addFeed,
+        removeFeed,
+        clearFeeds,
+        updateFeed,
+    };
+};

--- a/src/app/(home)/foryou/store/useFeedStore.ts
+++ b/src/app/(home)/foryou/store/useFeedStore.ts
@@ -5,8 +5,11 @@ interface FeedStore {
     feeds: Feed[];
     setFeeds: (feeds: Feed[] | ((prev: Feed[]) => Feed[])) => void;
     addFeed: (feed: Feed) => void;
+    addFeeds: (feeds: Feed[]) => void;
     updateFeed: (id: string, updater: (prev: Feed) => Feed) => void;
+    updateFeeds: (updates: Feed[]) => void;
     removeFeed: (id: string) => void;
+    removeFeeds: (ids: string[]) => void;
     clearFeeds: () => void;
 }
 
@@ -37,15 +40,27 @@ export const useFeedStore = create<FeedStore>((set) => ({
         });
     },
     addFeed: (feed) => set((state) => ({ feeds: [feed, ...state.feeds] })),
+    addFeeds: (newFeeds) => set((state) => ({ feeds: [...newFeeds, ...state.feeds] })),
     updateFeed: (id, updater) =>
         set((state) => ({
             feeds: state.feeds.map((f) =>
                 f.post.id === id ? updater(f) : f
             ),
         })),
+    updateFeeds: (updates) =>
+        set((state) => ({
+            feeds: state.feeds.map((f) => {
+                const updated = updates.find((u) => u.post.id === f.post.id);
+                return updated ? updated : f;
+            }),
+        })),
     removeFeed: (id) =>
         set((state) => ({
             feeds: state.feeds.filter((f) => f.post.id !== id),
+        })),
+    removeFeeds: (ids) =>
+        set((state) => ({
+            feeds: state.feeds.filter((f) => !ids.includes(f.post.id)),
         })),
     clearFeeds: () => set({ feeds: [] }),
 }));

--- a/src/app/admin/posts/all/hooks/usePostsRealtime.ts
+++ b/src/app/admin/posts/all/hooks/usePostsRealtime.ts
@@ -1,0 +1,37 @@
+import {useChannel} from "ably/react";
+import usePostsStore from "../stores/usePostsStore";
+import {useCurrentUser} from "@/stores/useCurrentUser";
+import {PostAdminViewDto, PostResponse} from "@/api/client/types.gen";
+
+export const usePostsRealtime = () => {
+    const {user} = useCurrentUser();
+    const {actions} = usePostsStore();
+
+    useChannel("posts", (message) => {
+        const {name, data, clientId} = message;
+        if (clientId === user?.id) return;
+
+        switch (name) {
+            case "post.created":
+                actions.addPost(data as PostAdminViewDto);
+                break;
+            case "post.updated":
+                actions.updatePost(data as PostResponse);
+                break;
+            case "post.deleted":
+                actions.removePost(data.postId as string);
+                break;
+            case "posts.bulk-created":
+                actions.addPosts(data.posts as PostAdminViewDto[]);
+                break;
+            case "posts.bulk-deleted":
+                actions.removePosts(data.postIds as string[]);
+                break;
+            case "posts.bulk-updated":
+                actions.updatePosts(data.posts as PostResponse[]);
+                break;
+            default:
+                console.warn(`[Ably] Unknown event "${name}" on posts channel`);
+        }
+    });
+};

--- a/src/app/admin/posts/all/hooks/usePostsSync.ts
+++ b/src/app/admin/posts/all/hooks/usePostsSync.ts
@@ -1,0 +1,33 @@
+import {useEffect} from "react";
+import {usePosts} from "./usePosts";
+import usePostsStore from "../stores/usePostsStore";
+
+export const usePostsSync = (postId?: string, dailyRange?: number) => {
+    const posts = usePosts(postId, dailyRange);
+    const {actions, posts: storePosts, selectedPost, overviewData, chartData} = usePostsStore();
+
+    useEffect(() => {
+        actions.setInfiniteQueryData(posts.postListData);
+    }, [posts.postListData, actions]);
+
+    useEffect(() => {
+        if (posts.postOverviewData?.data) {
+            actions.setOverviewData(posts.postOverviewData.data);
+        }
+    }, [posts.postOverviewData?.data, actions]);
+
+    useEffect(() => {
+        if (posts.dailyPostCount?.data) {
+            actions.setChartData(posts.dailyPostCount.data);
+        }
+    }, [posts.dailyPostCount?.data, actions]);
+
+    return {
+        ...posts,
+        posts: storePosts,
+        selectedPost,
+        overviewData,
+        chartData,
+        actions,
+    };
+};

--- a/src/app/admin/posts/all/post-card-list.tsx
+++ b/src/app/admin/posts/all/post-card-list.tsx
@@ -2,11 +2,11 @@
 
 import {OverviewList} from "@/app/admin/components/overview-list";
 import usePostsStore from "@/app/admin/posts/all/stores/usePostsStore";
-import {usePostsManagement} from "@/app/admin/posts/all/hooks/usePostsManagement";
+import {usePostsSync} from "@/app/admin/posts/all/hooks/usePostsSync";
 
 export const PostCardList = () => {
     const {overviewData} = usePostsStore()
-    const {isPostOverviewLoading} = usePostsManagement()
+    const {isPostOverviewLoading} = usePostsSync()
 
     return <OverviewList overviewData={overviewData} isLoading={isPostOverviewLoading} />
 }

--- a/src/app/admin/posts/all/post-chart.tsx
+++ b/src/app/admin/posts/all/post-chart.tsx
@@ -6,7 +6,7 @@ import { useTranslations } from "next-intl"
 
 import { ChartConfig } from "@/components/ui/chart"
 import { TimeRangeChart } from "@/components/common/time-range-chart"
-import { usePostsManagement } from "@/app/admin/posts/all/hooks/usePostsManagement"
+import { usePostsSync } from "@/app/admin/posts/all/hooks/usePostsSync"
 import usePostsStore from "@/app/admin/posts/all/stores/usePostsStore"
 import {normalizeChartData} from "@/lib/utils";
 
@@ -22,7 +22,7 @@ export function PostChart() {
     const t = useTranslations('Admin.posts.all.charts')
     const { chartData } = usePostsStore()
     const [days, setDays] = React.useState(30)
-    const { isDailyPostCountLoading } = usePostsManagement(undefined, days)
+    const { isDailyPostCountLoading } = usePostsSync(undefined, days)
 
     const handleTimeRangeChange = (days: number) => {
         setDays(days)

--- a/src/app/admin/posts/all/post-detail-viewer-sheet.tsx
+++ b/src/app/admin/posts/all/post-detail-viewer-sheet.tsx
@@ -49,7 +49,7 @@ import {Separator} from "@/components/ui/separator";
 import {Badge} from "@/components/ui/badge";
 import {PostStatusEnum, PostCategoryEnum} from "./post-schema";
 import Image from "next/image";
-import {usePostsManagement} from "@/app/admin/posts/all/hooks/usePostsManagement";
+import {usePostsSync} from "@/app/admin/posts/all/hooks/usePostsSync";
 import usePostsStore from "@/app/admin/posts/all/stores/usePostsStore";
 import {PostAdminViewDto} from "@/api/client";
 import {zPostAdminViewDto, zUpdatePostRequest} from "@/api/client/zod.gen";
@@ -83,7 +83,7 @@ export const PostDetailViewerSheet: React.FC<PostDetailViewerSheetProps> = ({
     const [post, setPostData] = React.useState<PostAdminViewDto | null>(null);
     const [isEditing, setIsEditing] = React.useState(false);
     const {actions: postStoreActions} = usePostsStore();
-    const {selectedPostData, updatePost, isUpdatingPost, isSelectedPostLoading} = usePostsManagement(postId);
+    const {selectedPostData, updatePost, isUpdatingPost, isSelectedPostLoading} = usePostsSync(postId);
     const t = useTranslations("Admin.posts.all");
 
     const form = useForm<EditablePostFormValues>({

--- a/src/app/admin/posts/all/post-table.tsx
+++ b/src/app/admin/posts/all/post-table.tsx
@@ -33,7 +33,7 @@ import {UserTableCellViewer} from "../../users/all/components/user-table-cell-vi
 import {formatDateTS, getFixedNumberFormat} from "@/lib/utils";
 import {PostAdminViewDto} from "@/api/client";
 import usePostsStore from "./stores/usePostsStore";
-import {usePostsManagement} from "@/app/admin/posts/all/hooks/usePostsManagement";
+import {usePostsSync} from "@/app/admin/posts/all/hooks/usePostsSync";
 import {usePostTableActions} from "@/app/admin/posts/all/use-post-table-actions";
 
 
@@ -46,7 +46,7 @@ export function PostTable() {
     const [selectedPostId, setSelectedPostId] = React.useState<string | null>(null);
     const [isSheetOpen, setIsSheetOpen] = React.useState(false);
 
-    const {isLoading, isFetchingNextPage, fetchNextPage, hasNextPage, deletePost, createPost} = usePostsManagement()
+    const {isLoading, isFetchingNextPage, fetchNextPage, hasNextPage, deletePost, createPost} = usePostsSync()
     const {posts} = usePostsStore();
 
     useEffect(() => {

--- a/src/app/admin/posts/all/use-post-table-actions.tsx
+++ b/src/app/admin/posts/all/use-post-table-actions.tsx
@@ -3,12 +3,12 @@ import {Download, Pencil, Trash} from "lucide-react";
 import {PostAdminViewDto} from "@/api/client";
 import {exportToExcel} from "@/lib/utils";
 import {BulkPostEditDialog} from "@/app/admin/posts/all/bulk-post-edit-dialog";
-import {usePostsManagement} from "@/app/admin/posts/all/hooks/usePostsManagement";
+import {usePostsSync} from "@/app/admin/posts/all/hooks/usePostsSync";
 import {zBulkPostUpdateRequest} from "@/api/client/zod.gen";
 import {useTranslations} from "next-intl";
 
 export const usePostTableActions = (items: PostAdminViewDto[]): FloatingBarAction[] => {
-    const {bulkDeletePosts, bulkUpdatePosts} = usePostsManagement();
+    const {bulkDeletePosts, bulkUpdatePosts} = usePostsSync();
     const t = useTranslations("Admin.posts.all.table");
     const postIds = items.map(item => item.id!);
 

--- a/src/app/components/post-presentation/video-section/ActionButtonGroup.tsx
+++ b/src/app/components/post-presentation/video-section/ActionButtonGroup.tsx
@@ -3,7 +3,7 @@ import {BookMarked, Heart, MessageSquareMore} from "lucide-react";
 import React from "react";
 import {Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from "@/components/ui/tooltip";
 import {Statistic} from "@/types/Feed";
-import {useFeedActions} from "@/app/(home)/foryou/hooks/useFeedAction";
+import {useFeed} from "@/app/(home)/foryou/hooks/useFeed";
 import {MoreAction} from "@/app/components/post-presentation/video-section/MoreAction";
 import {useTranslations} from "next-intl";
 
@@ -15,7 +15,7 @@ interface ActionButtonGroupProps {
 
 const ActionButtonGroup = ({setIsCommentOpened, postId, statistic}: ActionButtonGroupProps) => {
     const t = useTranslations("Home.posts.actions");
-    const {handleLike, handleBookmark} = useFeedActions();
+    const {handleLike, handleBookmark} = useFeed();
 
     const handleCommentToggle = () => {
         setIsCommentOpened?.((prev) => !prev);

--- a/src/app/components/post-presentation/video-section/MoreAction.tsx
+++ b/src/app/components/post-presentation/video-section/MoreAction.tsx
@@ -1,4 +1,4 @@
-import {useFeedActions} from "@/app/(home)/foryou/hooks/useFeedAction";
+import {useFeed} from "@/app/(home)/foryou/hooks/useFeed";
 import {Tooltip, TooltipContent, TooltipTrigger} from "@/components/ui/tooltip";
 import {
     DropdownMenu,
@@ -19,7 +19,7 @@ import {useTranslations} from "next-intl";
 export const MoreAction = ({postId}: { postId: string }) => {
     const actionsT = useTranslations("Home.posts.actions");
     const reportT = useTranslations("Home.posts.report");
-    const {handleShareLink, handleReportPost} = useFeedActions();
+    const {handleShareLink, handleReportPost} = useFeed();
 
     const reportReasons = [
         { key: "sexual_content", value: reportT("sexual_content") },


### PR DESCRIPTION
## Summary
- split admin posts hook into separate fetching and store syncing hooks
- add realtime hook for admin posts updates
- extend admin posts store with bulk helpers
- update components to use `usePostsSync`
- ensure mutations update zustand store immediately

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_684e5bd275a08326966b9358b9968e36