### PR TITLE
Add global app states

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import {useEffect} from 'react';
+import {Button} from '@/components/ui/button';
+
+export default function Error({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+    useEffect(() => {
+        console.error(error);
+    }, [error]);
+
+    return (
+        <div className="flex flex-col items-center justify-center gap-3 py-10">
+            <h2 className="text-xl font-semibold">Something went wrong!</h2>
+            <Button onClick={() => reset()}>Try again</Button>
+        </div>
+    );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,6 +9,7 @@ import QueryProvider from "@/components/query-provider";
 import {UserProvider} from "@/components/user-provider";
 import ClientSetupProvider from "@/components/client-setup-provider";
 import {MaintenanceWrapper} from "@/components/maintenance-wrapper";
+import {ErrorBoundary} from "@/components/error-boundary";
 import {ClientInitProvider} from "@/components/client-init-provider";
 import {getLocale} from "next-intl/server";
 import {NextIntlClientProvider} from "next-intl";
@@ -56,7 +57,9 @@ export default async function RootLayout({
                                         disableTransitionOnChange
                                     >
                                         <MaintenanceWrapper>
-                                            {children}
+                                            <ErrorBoundary>
+                                                {children}
+                                            </ErrorBoundary>
                                         </MaintenanceWrapper>
                                         <Toaster richColors/>
                                     </ThemeProvider>

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,0 +1,9 @@
+import {Spinner} from '@/components/ui/spinner';
+
+export default function Loading() {
+    return (
+        <div className="flex flex-1 h-full items-center justify-center py-10">
+            <Spinner size="large" />
+        </div>
+    );
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,14 @@
+import Link from 'next/link';
+import {Button} from '@/components/ui/button';
+
+export default function NotFound() {
+    return (
+        <div className="flex flex-col items-center justify-center gap-3 py-10">
+            <h2 className="text-3xl font-bold">404 - Not Found</h2>
+            <p className="text-muted-foreground">Could not find the requested page.</p>
+            <Button asChild>
+                <Link href="/">Go back home</Link>
+            </Button>
+        </div>
+    );
+}

--- a/src/components/error-boundary.tsx
+++ b/src/components/error-boundary.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import React from 'react';
+
+interface ErrorBoundaryProps {
+  children: React.ReactNode;
+  fallback?: React.ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    console.error('ErrorBoundary caught an error', error, info);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback ?? <p>Something went wrong.</p>;
+    }
+
+    return this.props.children;
+  }
+}


### PR DESCRIPTION
## Summary
- implement `loading.tsx`, `error.tsx` and `not-found.tsx` for the main app
- add a simple error boundary component
- wrap app content with the error boundary in the root layout

## Testing
- `npm run lint`
- `npm run build` *(fails: Argument of type 'CommentRespond' is not assignable to parameter of type 'Partial<CommentResponseWithPostDetails> & { id: string; }')*

------
https://chatgpt.com/codex/tasks/task_b_68526a431ab883268db1878692204141