### PR TITLE
Localize admin UI

### DIFF
--- a/src/app/admin/components/appbar/app-document.tsx
+++ b/src/app/admin/components/appbar/app-document.tsx
@@ -13,6 +13,7 @@ import {
     DropdownMenuItem,
     DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
+import {useTranslations} from "next-intl"
 import {
     SidebarGroup,
     SidebarGroupLabel,
@@ -34,10 +35,11 @@ export function NavDocuments({
     }[]
 }) {
     const {isMobile} = useSidebar()
+    const t = useTranslations('Admin.appBar')
 
     return (
         <SidebarGroup className="group-data-[collapsible=icon]:hidden">
-            <SidebarGroupLabel>Documents</SidebarGroupLabel>
+            <SidebarGroupLabel>{t('documents')}</SidebarGroupLabel>
             <SidebarMenu>
                 {items.map((item) => (
                     <SidebarMenuItem key={item.name}>
@@ -54,7 +56,7 @@ export function NavDocuments({
                                     className="rounded-sm data-[state=open]:bg-accent"
                                 >
                                     <MoreHorizontalIcon/>
-                                    <span className="sr-only">More</span>
+                                    <span className="sr-only">{t('more')}</span>
                                 </SidebarMenuAction>
                             </DropdownMenuTrigger>
                             <DropdownMenuContent
@@ -64,11 +66,11 @@ export function NavDocuments({
                             >
                                 <DropdownMenuItem>
                                     <FolderIcon/>
-                                    <span>Open</span>
+                                    <span>{t('open')}</span>
                                 </DropdownMenuItem>
                                 <DropdownMenuItem>
                                     <ShareIcon/>
-                                    <span>Share</span>
+                                    <span>{t('share')}</span>
                                 </DropdownMenuItem>
                             </DropdownMenuContent>
                         </DropdownMenu>
@@ -77,7 +79,7 @@ export function NavDocuments({
                 <SidebarMenuItem>
                     <SidebarMenuButton className="text-sidebar-foreground/70">
                         <MoreHorizontalIcon className="text-sidebar-foreground/70"/>
-                        <span>More</span>
+                        <span>{t('more')}</span>
                     </SidebarMenuButton>
                 </SidebarMenuItem>
             </SidebarMenu>

--- a/src/app/admin/components/appbar/app-main.tsx
+++ b/src/app/admin/components/appbar/app-main.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import {MailIcon, PlusCircleIcon, type LucideIcon, ChevronRight} from "lucide-react"
+import {useTranslations} from "next-intl"
 
 import {Button} from "@/components/ui/button"
 import {
@@ -30,6 +31,7 @@ export function NavMain({
     }[]
 }) {
     const pathname = usePathname();
+    const t = useTranslations('Admin.appBar');
 
     return (
         <SidebarGroup>
@@ -37,11 +39,11 @@ export function NavMain({
                 <SidebarMenu>
                     <SidebarMenuItem className="flex items-center gap-2">
                         <SidebarMenuButton
-                            tooltip="Quick Create"
+                            tooltip={t('quickCreate')}
                             className="min-w-8 bg-primary text-primary-foreground duration-200 ease-linear hover:bg-primary/90 hover:text-primary-foreground active:bg-primary/90 active:text-primary-foreground"
                         >
                             <PlusCircleIcon/>
-                            <span>Quick Create</span>
+                            <span>{t('quickCreate')}</span>
                         </SidebarMenuButton>
                         <Button
                             size="icon"
@@ -49,7 +51,7 @@ export function NavMain({
                             variant="outline"
                         >
                             <MailIcon/>
-                            <span className="sr-only">Inbox</span>
+                            <span className="sr-only">{t('inbox')}</span>
                         </Button>
                     </SidebarMenuItem>
                 </SidebarMenu>

--- a/src/app/admin/components/appbar/app-sidebar.tsx
+++ b/src/app/admin/components/appbar/app-sidebar.tsx
@@ -30,124 +30,120 @@ import {UserAssistance} from "@/app/components/user_dialog/UserAssistance";
 import {NavDocuments} from "@/app/admin/components/appbar/app-document";
 import {NavMain} from "@/app/admin/components/appbar/app-main";
 import {NavSecondary} from "@/app/admin/components/appbar/app-secondary";
-import {useEffect} from "react";
+import {useEffect, useMemo} from "react";
 import { NavSystem } from "@/app/admin/components/appbar/app-cloud";
+import {useTranslations} from "next-intl";
 
-const data = {
-    user: {
-        name: "Admin",
-        email: "admin@example.com",
-        avatar: "/avatars/admin.jpg",
-    },
-    navMain: [
-        {
-            title: "Dashboard",
-            url: "/admin/dashboard",
-            icon: LayoutDashboardIcon,
-        },
-        {
-            title: "Users",
-            url: "/admin/users",
-            icon: UsersIcon,
-            subItems: [
-                { title: "All Users", url: "/admin/users/all" },
-                { title: "Reports", url: "/admin/users/reports" },
-                { title: "Roles", url: "/admin/users/roles" },
-                { title: "Permissions", url: "/admin/users/permissions" },
-            ],
-        },
-        {
-            title: "Posts",
-            url: "/admin/posts",
-            icon: FileTextIcon,
-            subItems: [
-                { title: "All Posts", url: "/admin/posts/all" },
-                { title: "Reports", url: "/admin/posts/reports" },
-                { title: "Categories", url: "/admin/posts/categories" },
-                { title: "Tags", url: "/admin/posts/tags" },
-            ],
-        },
-        {
-            title: "Comments",
-            url: "/admin/comments",
-            icon: MessageSquareIcon,
-            subItems: [
-                { title: "All Comments", url: "/admin/comments/all" },
-                { title: "Reports", url: "/admin/comments/reports" },
-            ],
-        },
-        {
-            title: "Moderation",
-            url: "/admin/moderation",
-            icon: ShieldCheckIcon,
-            subItems: [
-                { title: "All Reports", url: "/admin/moderation/reports" },
-                { title: "User Reports", url: "/admin/users/reports" },
-                { title: "Post Reports", url: "/admin/posts/reports" },
-                { title: "Comment Reports", url: "/admin/comments/reports" },
-                { title: "Notifications", url: "/admin/moderation/notifications" },
-            ],
-        },
-    ],
-
-    navSystem: [
-        {
-            title: "System",
-            icon: ServerIcon,
-            url: "#",
-            items: [
-                { title: "Status & Uptime", url: "/admin/system/status" },
-                { title: "Maintenance Mode", url: "/admin/system/maintenance" },
-                { title: "Database Schema", url: "/admin/system/database-schema" },
-            ],
-        },
-        {
-            title: "Logs",
-            icon: ListIcon,
-            url: "/admin/system/logs",
-        },
-    ],
-
-    navSecondary: [
-        {
-            title: "Settings",
-            url: "/admin/settings",
-            icon: SettingsIcon,
-        },
-        {
-            title: "Get Help",
-            url: "/support",
-            icon: HelpCircleIcon,
-        },
-        {
-            title: "Search",
-            url: "#",
-            icon: SearchIcon,
-        },
-    ],
-
-    documents: [
-        {
-            name: "User Guide",
-            url: "docs/user-guide",
-            icon: FileIcon,
-        },
-        {
-            name: "API Reference",
-            url: "/admin/docs/api",
-            icon: ClipboardListIcon,
-        },
-        {
-            name: "Database Schema",
-            url: "docs/database",
-            icon: DatabaseIcon,
-        },
-    ],
-};
 
 export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
     const [isCollapsible, setIsCollapsible] = React.useState(false)
     const {state} = useSidebar()
+    const t = useTranslations('Admin.appBar')
+    const tSystem = useTranslations('Admin.system')
+
+    const data = useMemo(() => ({
+        navMain: [
+            {
+                title: t('dashboard'),
+                url: '/admin/dashboard',
+                icon: LayoutDashboardIcon,
+            },
+            {
+                title: t('users'),
+                url: '/admin/users',
+                icon: UsersIcon,
+                subItems: [
+                    { title: t('allUsers'), url: '/admin/users/all' },
+                    { title: t('userReports'), url: '/admin/users/reports' },
+                    { title: t('roles'), url: '/admin/users/roles' },
+                    { title: t('permissions'), url: '/admin/users/permissions' },
+                ],
+            },
+            {
+                title: t('posts'),
+                url: '/admin/posts',
+                icon: FileTextIcon,
+                subItems: [
+                    { title: t('allPosts'), url: '/admin/posts/all' },
+                    { title: t('postReports'), url: '/admin/posts/reports' },
+                    { title: t('categories'), url: '/admin/posts/categories' },
+                    { title: t('tags'), url: '/admin/posts/tags' },
+                ],
+            },
+            {
+                title: t('comments'),
+                url: '/admin/comments',
+                icon: MessageSquareIcon,
+                subItems: [
+                    { title: t('allComments'), url: '/admin/comments/all' },
+                    { title: t('commentReports'), url: '/admin/comments/reports' },
+                ],
+            },
+            {
+                title: t('moderation'),
+                url: '/admin/moderation',
+                icon: ShieldCheckIcon,
+                subItems: [
+                    { title: t('allReports'), url: '/admin/moderation/reports' },
+                    { title: t('userReportsNav'), url: '/admin/users/reports' },
+                    { title: t('postReportsNav'), url: '/admin/posts/reports' },
+                    { title: t('commentReportsNav'), url: '/admin/comments/reports' },
+                    { title: t('notifications'), url: '/admin/moderation/notifications' },
+                ],
+            },
+        ],
+        navSystem: [
+            {
+                title: t('system'),
+                icon: ServerIcon,
+                url: '#',
+                items: [
+                    { title: tSystem('statusUptimeNav'), url: '/admin/system/status' },
+                    { title: t('maintenance'), url: '/admin/system/maintenance' },
+                    { title: t('databaseSchema'), url: '/admin/system/database-schema' },
+                ],
+            },
+            {
+                title: t('logs'),
+                icon: ListIcon,
+                url: '/admin/system/logs',
+            },
+        ],
+        navSecondary: [
+            {
+                title: t('settings'),
+                url: '/admin/settings',
+                icon: SettingsIcon,
+            },
+            {
+                title: t('getHelp'),
+                url: '/support',
+                icon: HelpCircleIcon,
+            },
+            {
+                title: t('search'),
+                url: '#',
+                icon: SearchIcon,
+            },
+        ],
+        documents: [
+            {
+                name: t('userGuide'),
+                url: 'docs/user-guide',
+                icon: FileIcon,
+            },
+            {
+                name: t('apiReference'),
+                url: '/admin/docs/api',
+                icon: ClipboardListIcon,
+            },
+            {
+                name: t('databaseSchema'),
+                url: 'docs/database',
+                icon: DatabaseIcon,
+            },
+        ],
+    }), [t, tSystem])
     
     useEffect(() => {
         if (state === 'collapsed') {

--- a/src/app/admin/system/status/components/status-container.tsx
+++ b/src/app/admin/system/status/components/status-container.tsx
@@ -2,6 +2,7 @@
 
 import {Badge} from "@/components/ui/badge"
 import {AlertTriangle, CheckCircle, Settings} from "lucide-react"
+import {useTranslations} from "next-intl"
 import {DatabaseStatus} from "./database-status"
 import {MaintenanceStatus} from "./maintenance-status"
 import {CloudinaryStatus} from "@/app/admin/system/status/components/cloudinary-status";
@@ -78,13 +79,14 @@ export interface StatusData {
 
 export const StatusContainer = () => {
     const {data: dataRetrieved, isLoading} = useSystemStatus()
+    const t = useTranslations('Admin.system.status')
     const data = dataRetrieved as unknown as StatusData;
 
     if (!data || isLoading) {
         return (
             <div className={'h-screen flex flex-col items-center justify-center'}>
                 <Spinner/>
-                <div className="text-center py-8">Loading system status...</div>
+                <div className="text-center py-8">{t('loading')}</div>
             </div>
         )
     }
@@ -102,28 +104,28 @@ export const StatusContainer = () => {
     return (
         <div className="container mx-auto py-8 px-4">
             <div className="mb-8 text-center">
-                <h1 className="text-3xl font-bold mb-2">System Status</h1>
+                <h1 className="text-3xl font-bold mb-2">{t('title')}</h1>
                 <div className="flex items-center justify-center gap-2">
                     {overallStatus === "operational" && (
                         <Badge className="bg-green-500 hover:bg-green-600">
                             <CheckCircle className="h-4 w-4 mr-1"/>
-                            All Systems Operational
+                            {t('overall.operational')}
                         </Badge>
                     )}
                     {overallStatus === "degraded" && (
                         <Badge className="bg-amber-500 hover:bg-amber-600">
                             <AlertTriangle className="h-4 w-4 mr-1"/>
-                            Some Systems Degraded
+                            {t('overall.degraded')}
                         </Badge>
                     )}
                     {overallStatus === "maintenance" && (
                         <Badge className="bg-blue-500 hover:bg-blue-600">
                             <Settings className="h-4 w-4 mr-1 animate-spin"/>
-                            System Maintenance
+                            {t('overall.maintenance')}
                         </Badge>
                     )}
                 </div>
-                <p className="text-muted-foreground mt-2">Last updated: {new Date().toLocaleString()}</p>
+                <p className="text-muted-foreground mt-2">{t('lastUpdated', {time: new Date().toLocaleString()})}</p>
             </div>
 
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6">

--- a/src/app/admin/system/status/status-container.tsx
+++ b/src/app/admin/system/status/status-container.tsx
@@ -2,10 +2,13 @@
 
 import {SiteHeader} from "@/app/admin/components/site-header";
 import { StatusContainer } from "./components/status-container";
+import {useTranslations} from "next-intl";
 
 export function AdminStatusContainer() {
+    const t = useTranslations('Admin.system.status');
+
     return <div className={"h-screen"}>
-        <SiteHeader text={"System Status"}/>
+        <SiteHeader text={t('title')}/>
         <StatusContainer/>
     </div>;
 }

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -764,6 +764,44 @@
         "exportToExcel": "Export to Excel"
       }
     },
+    "appBar": {
+      "quickCreate": "Quick Create",
+      "inbox": "Inbox",
+      "documents": "Documents",
+      "userGuide": "User Guide",
+      "apiReference": "API Reference",
+      "databaseSchema": "Database Schema",
+      "open": "Open",
+      "share": "Share",
+      "more": "More",
+      "settings": "Settings",
+      "getHelp": "Get Help",
+      "search": "Search",
+      "dashboard": "Dashboard",
+      "users": "Users",
+      "allUsers": "All Users",
+      "userReports": "Reports",
+      "roles": "Roles",
+      "permissions": "Permissions",
+      "posts": "Posts",
+      "allPosts": "All Posts",
+      "postReports": "Reports",
+      "categories": "Categories",
+      "tags": "Tags",
+      "comments": "Comments",
+      "allComments": "All Comments",
+      "commentReports": "Reports",
+      "moderation": "Moderation",
+      "allReports": "All Reports",
+      "postReportsNav": "Post Reports",
+      "userReportsNav": "User Reports",
+      "commentReportsNav": "Comment Reports",
+      "notifications": "Notifications",
+      "system": "System",
+      "statusUptime": "Status & Uptime",
+      "maintenance": "Maintenance Mode",
+      "logs": "Logs"
+    },
     "dashboard": {
       "title": "Dashboard",
       "tabs": {
@@ -1421,6 +1459,7 @@
     },
     "system": {
       "title": "System",
+      "statusUptimeNav": "Status & Uptime",
       "status": {
         "title": "System Status",
         "description": "Monitor the health and status of all system components",
@@ -1439,6 +1478,13 @@
           "maintenance": "Under Maintenance",
           "unknown": "Status Unknown"
         },
+        "overall": {
+          "operational": "All Systems Operational",
+          "degraded": "Some Systems Degraded",
+          "maintenance": "System Maintenance"
+        },
+        "loading": "Loading system status...",
+        "lastUpdated": "Last updated: {time}",
         "metrics": {
           "uptime": "Uptime",
           "responseTime": "Response Time",

--- a/src/messages/vn.json
+++ b/src/messages/vn.json
@@ -756,6 +756,44 @@
         "exportToExcel": "Xuất sang Excel"
       }
     },
+    "appBar": {
+      "quickCreate": "Tạo nhanh",
+      "inbox": "Hộp thư",
+      "documents": "Tài liệu",
+      "userGuide": "Hướng dẫn sử dụng",
+      "apiReference": "Tài liệu API",
+      "databaseSchema": "Lược đồ CSDL",
+      "open": "Mở",
+      "share": "Chia sẻ",
+      "more": "Thêm",
+      "settings": "Cài đặt",
+      "getHelp": "Trợ giúp",
+      "search": "Tìm kiếm",
+      "dashboard": "Bảng điều khiển",
+      "users": "Người dùng",
+      "allUsers": "Tất cả người dùng",
+      "userReports": "Báo cáo",
+      "roles": "Vai trò",
+      "permissions": "Quyền hạn",
+      "posts": "Bài viết",
+      "allPosts": "Tất cả bài viết",
+      "postReports": "Báo cáo",
+      "categories": "Danh mục",
+      "tags": "Thẻ",
+      "comments": "Bình luận",
+      "allComments": "Tất cả bình luận",
+      "commentReports": "Báo cáo",
+      "moderation": "Kiểm duyệt",
+      "allReports": "Tất cả báo cáo",
+      "postReportsNav": "Báo cáo bài viết",
+      "userReportsNav": "Báo cáo người dùng",
+      "commentReportsNav": "Báo cáo bình luận",
+      "notifications": "Thông báo",
+      "system": "Hệ thống",
+      "statusUptime": "Trạng thái & thời gian hoạt động",
+      "maintenance": "Chế độ bảo trì",
+      "logs": "Nhật ký"
+    },
     "dashboard": {
       "title": "Bảng điều khiển",
       "tabs": {
@@ -1412,6 +1450,7 @@
     },
     "system": {
       "title": "System",
+      "statusUptimeNav": "Trạng thái & thời gian hoạt động",
       "status": {
         "title": "Trạng thái hệ thống",
         "description": "Theo dõi tình trạng và trạng thái của tất cả các thành phần trong hệ thống",
@@ -1430,6 +1469,13 @@
           "maintenance": "Đang bảo trì",
           "unknown": "Không xác định"
         },
+        "overall": {
+          "operational": "Tất cả hệ thống hoạt động ổn định",
+          "degraded": "Một số hệ thống gặp sự cố",
+          "maintenance": "Hệ thống đang bảo trì"
+        },
+        "loading": "Đang tải trạng thái hệ thống...",
+        "lastUpdated": "Cập nhật lần cuối: {time}",
         "metrics": {
           "uptime": "Thời gian hoạt động",
           "responseTime": "Thời gian phản hồi",


### PR DESCRIPTION
## Summary
- add translation keys for admin appbar and system status page
- load translations in admin sidebar and documents menus
- localize quick create, inbox, and other sidebar items
- translate system status page strings

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6853a221be188326b7082b3db21a6e8e